### PR TITLE
fix: remove execution_count from display_data type output

### DIFF
--- a/plugins/kernel/txl_kernel/driver.py
+++ b/plugins/kernel/txl_kernel/driver.py
@@ -181,7 +181,15 @@ class KernelMixin:
                     )
                 else:
                     outputs[-1]["text"].append(content["text"])  # type: ignore
-        elif msg_type in ("display_data", "execute_result"):
+        elif msg_type == "display_data":
+            outputs.append(
+                {
+                    "data": content["data"],
+                    "metadata": {},
+                    "output_type": msg_type,
+                }
+            )
+        elif msg_type == "execute_result":
             outputs.append(
                 {
                     "data": content["data"],


### PR DESCRIPTION
Fix the bug that display_data does not have execution_count and it will raise an Exception when receiving display_data

https://jupyter-client.readthedocs.io/en/latest/messaging.html#display-data
https://jupyter-client.readthedocs.io/en/latest/messaging.html#id7



