### PR TITLE
fix: support stdout/stderr after display data

### DIFF
--- a/plugins/kernel/txl_kernel/driver.py
+++ b/plugins/kernel/txl_kernel/driver.py
@@ -169,7 +169,7 @@ class KernelMixin:
         content = msg["content"]
         if msg_type == "stream":
             with outputs.doc.transaction():
-                if (not outputs) or (outputs[-1]["name"] != content["name"]):  # type: ignore
+                if (not outputs) or (outputs[-1].get("name") != content["name"]):  # type: ignore
                     outputs.append(
                         Map(
                             {


### PR DESCRIPTION
@davidbrochart When stderr/stdout is after a display data, output[-1] does not have a "name" key. This patch fixes it.