### PR TITLE
feat: add timeout argument to txl_remote_kernels

### DIFF
--- a/plugins/cell/txl_cell/main.py
+++ b/plugins/cell/txl_cell/main.py
@@ -10,6 +10,7 @@ from rich.text import Text as RichText
 from textual.app import ComposeResult
 from textual.containers import Container
 from textual.widgets import Static
+
 from txl.base import Cell, CellFactory, Contents, Kernel, Widgets
 from txl.text_input import TextInput
 

--- a/plugins/remote_kernels/txl_remote_kernels/main.py
+++ b/plugins/remote_kernels/txl_remote_kernels/main.py
@@ -8,6 +8,7 @@ from anyio import create_task_group, sleep
 from fps import Module
 from httpx import USE_CLIENT_DEFAULT, Timeout
 from pycrdt import Map
+
 from txl.base import Kernels, Kernelspecs
 
 from .driver import KernelDriver


### PR DESCRIPTION
In low-performance machine, the websocket may timeout before the tornado server responds. This fix explicitly specifies the timeout parameter passed to the websocket.

Related:
https://github.com/jupyter-server/jupyter_server/issues/1265#issuecomment-2456851783
https://github.com/jupyter-server/jupyter_server/blob/987ebdd5e188cdc49751b01a0d6782d686492a53/jupyter_server/services/kernels/websocket.py#L59
(AI said this prepare() function could take several seconds to complete, while httpx default timeout is 5 seconds)

@davidbrochart 